### PR TITLE
feat: multiledger → Core

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
 'use strict'
 
 exports.Client = require('./src/lib/client')
+exports.Core = require('./src/lib/core')

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "co": "^4.6.0",
-    "eventemitter2": "^1.0.3",
+    "eventemitter2": "^2.0.0",
     "lodash": "^4.13.1",
     "superagent": "^2.0.0",
     "uuid": "^2.0.2"

--- a/src/lib/client.js
+++ b/src/lib/client.js
@@ -24,11 +24,13 @@ class Client extends EventEmitter {
     this.plugin = new Plugin(opts)
     this.connecting = false
 
-    this.plugin.on('receive', (transfer) => this.emit('receive', transfer))
-    this.plugin.on('fulfill_execution_condition', (transfer, fulfillment) =>
-      this.emit('fulfill_execution_condition', transfer, fulfillment))
-    this.plugin.on('fulfill_cancellation_condition', (transfer, fulfillment) =>
-      this.emit('fulfill_cancellation_condition', transfer, fulfillment))
+    const _this = this
+    this.plugin
+      .on('receive', (transfer) => this.emitAsync('receive', transfer))
+      .on('fulfill_execution_condition', (transfer, fulfillment) =>
+        this.emitAsync('fulfill_execution_condition', transfer, fulfillment))
+      .on('fulfill_cancellation_condition', (transfer, fulfillment) =>
+        this.emitAsync('fulfill_cancellation_condition', transfer, fulfillment))
 
     this._extensions = {}
   }

--- a/src/lib/client.js
+++ b/src/lib/client.js
@@ -24,7 +24,6 @@ class Client extends EventEmitter {
     this.plugin = new Plugin(opts)
     this.connecting = false
 
-    const _this = this
     this.plugin
       .on('receive', (transfer) => this.emitAsync('receive', transfer))
       .on('fulfill_execution_condition', (transfer, fulfillment) =>

--- a/src/lib/core.js
+++ b/src/lib/core.js
@@ -53,9 +53,8 @@ class Core extends EventEmitter {
       this.clients[prefix] = client
     }
 
-    client.onAny(function * (event, arg1, arg2, arg3) {
-      yield this.emitAsync(event, client, arg1, arg2, arg3)
-    })
+    client.onAny((event, arg1, arg2, arg3) =>
+      this.emitAsync(event, client, arg1, arg2, arg3))
   }
 
   connect () {

--- a/src/lib/core.js
+++ b/src/lib/core.js
@@ -21,6 +21,11 @@ class Core extends EventEmitter {
     return null
   }
 
+  resolvePlugin (address) {
+    const client = this.resolve(address)
+    return client && client.getPlugin()
+  }
+
   /**
    * @param {String} address
    * @returns {Boolean}
@@ -40,14 +45,16 @@ class Core extends EventEmitter {
   addClient (client) {
     this.clientList.push(client)
 
+    /*
     const prefixes = makeAddressPrefixes(client.plugin.getPrefix())
+    */
+    const prefixes = makeAddressPrefixes(client.plugin.id)
     for (const prefix of prefixes) {
       this.clients[prefix] = client
     }
 
-    const _this = this
     client.onAny(function * (event, arg1, arg2, arg3) {
-      yield _this.emitAsync.call(_this, event, client, arg1, arg2, arg3)
+      yield this.emitAsync(event, client, arg1, arg2, arg3)
     })
   }
 
@@ -65,9 +72,12 @@ class Core extends EventEmitter {
  * @returns {String[]} Returns a list of address prefixes, longest-to-shortest.
  */
 function makeAddressPrefixes (address) {
+  return [address]
+  /*
   const parts = address.split('.')
   const partCount = parts.length
   return parts.map((_, i) => parts.slice(0, partCount - i).join('.'))
+  */
 }
 
 module.exports = Core

--- a/src/lib/core.js
+++ b/src/lib/core.js
@@ -1,0 +1,73 @@
+'use strict'
+
+const EventEmitter = require('eventemitter2')
+
+class Core extends EventEmitter {
+  constructor () {
+    super()
+    this.clientList = [] // Client[]
+    this.clients = {} // { prefix ⇒ Client }
+  }
+
+  /**
+   * @param {String} address
+   * @returns {Client|null}
+   */
+  resolve (address) {
+    const prefixes = makeAddressPrefixes(address)
+    for (const prefix of prefixes) {
+      if (this.clients[prefix]) return this.clients[prefix]
+    }
+    return null
+  }
+
+  /**
+   * @param {String} address
+   * @returns {Boolean}
+   */
+  isLocalAddress (address) {
+    return !!this.resolve(address)
+  }
+
+  /**
+   * @returns {Client[]}
+   */
+  getClients () { return this.clientList.slice() }
+
+  /**
+   * @param {Client} client
+   */
+  addClient (client) {
+    this.clientList.push(client)
+
+    const prefixes = makeAddressPrefixes(client.plugin.getPrefix())
+    for (const prefix of prefixes) {
+      this.clients[prefix] = client
+    }
+
+    const _this = this
+    client.onAny(function * (event, arg1, arg2, arg3) {
+      yield _this.emitAsync.call(_this, event, client, arg1, arg2, arg3)
+    })
+  }
+
+  connect () {
+    return Promise.all(this.clientList.map((client) => client.connect()))
+  }
+
+  disconnect () {
+    return Promise.all(this.clientList.map((client) => client.disconnect()))
+  }
+}
+
+/**
+ * @param {String} address
+ * @returns {String[]} Returns a list of address prefixes, longest-to-shortest.
+ */
+function makeAddressPrefixes (address) {
+  const parts = address.split('.')
+  const partCount = parts.length
+  return parts.map((_, i) => parts.slice(0, partCount - i).join('.'))
+}
+
+module.exports = Core

--- a/test/coreSpec.js
+++ b/test/coreSpec.js
@@ -1,0 +1,134 @@
+'use strict'
+
+const sinon = require('sinon')
+const chai = require('chai')
+sinon.assert.expose(chai.assert, { prefix: '' })
+const chaiAsPromised = require('chai-as-promised')
+chai.use(chaiAsPromised)
+const assert = chai.assert
+
+const mockRequire = require('mock-require')
+const MockPlugin = require('./mocks/mock-plugin')
+
+const MockClient = require('./mocks/mock-client')
+const Core = require('../src/lib/core')
+
+describe('Core', function () {
+  beforeEach(function () {
+    mockRequire('ilp-plugin-mock', MockPlugin)
+    this.core = new Core()
+  })
+
+  afterEach(function () {
+    mockRequire.stopAll()
+  })
+
+  describe('constructor', function () {
+    it('should instantiate a Core', function () {
+      const core = new Core()
+      assert.instanceOf(core, Core)
+      assert.deepEqual(core.clientList, [])
+      assert.deepEqual(core.clients, {})
+    })
+  })
+
+  describe('resolve', function () {
+    it('returns the corresponding Client', function () {
+      const client1 = new MockClient({id: 'http://ledger1.mock'})
+      const client2 = new MockClient({id: 'http://ledger2.mock'})
+      this.core.addClient(client1)
+      this.core.addClient(client2)
+      assert.equal(this.core.resolve('http://ledger1.mock'), client1)
+      assert.equal(this.core.resolve('http://ledger2.mock'), client2)
+    })
+
+    it('returns null if no Client matches', function () {
+      assert.strictEqual(this.core.resolve('http://ledger1.mock'), null)
+    })
+  })
+
+  describe('resolvePlugin', function () {
+    it('returns the corresponding plugin', function () {
+      const client1 = new MockClient({id: 'http://ledger1.mock'})
+      const client2 = new MockClient({id: 'http://ledger2.mock'})
+      this.core.addClient(client1)
+      this.core.addClient(client2)
+      assert.equal(this.core.resolvePlugin('http://ledger1.mock'), client1.plugin)
+      assert.equal(this.core.resolvePlugin('http://ledger2.mock'), client2.plugin)
+    })
+
+    it('returns null if there is no match', function () {
+      assert.strictEqual(this.core.resolvePlugin('http://ledger1.mock'), null)
+    })
+  })
+
+  describe('isLocalAddress', function () {
+    it('returns true if a client matches', function () {
+      this.core.addClient(new MockClient({id: 'http://ledger1.mock'}))
+      assert.strictEqual(this.core.isLocalAddress('http://ledger1.mock'), true)
+    })
+
+    it('returns false if no client matches', function () {
+      assert.strictEqual(this.core.isLocalAddress('http://ledger1.mock'), false)
+    })
+  })
+
+  describe('getClients', function () {
+    it('returns a list of clients', function () {
+      const client1 = new MockClient({id: 'http://ledger1.mock'})
+      const client2 = new MockClient({id: 'http://ledger2.mock'})
+      this.core.addClient(client1)
+      this.core.addClient(client2)
+      assert.deepEqual(this.core.getClients(), [client1, client2])
+    })
+
+    it('returns [] when there are no clients', function () {
+      assert.deepEqual(this.core.getClients(), [])
+    })
+  })
+
+  describe('addClient', function () {
+    it('propagates events', function (done) {
+      const client1 = new MockClient({id: 'http://ledger1.mock'})
+      this.core.addClient(client1)
+      this.core.on('foobar', function (client, arg1, arg2, arg3) {
+        assert.equal(client, client1)
+        assert.equal(arg1, 1)
+        assert.equal(arg2, 2)
+        assert.equal(arg3, 3)
+        done()
+      })
+      client1.emit('foobar', 1, 2, 3)
+    })
+  })
+
+  describe('connect', function () {
+    it('connects all clients', function * () {
+      const client1 = new MockClient({id: 'http://ledger1.mock'})
+      const client2 = new MockClient({id: 'http://ledger2.mock'})
+      this.core.addClient(client1)
+      this.core.addClient(client2)
+
+      const spy1 = sinon.spy(client1, 'connect')
+      const spy2 = sinon.spy(client2, 'connect')
+      yield this.core.connect()
+      assert.calledOnce(spy1)
+      assert.calledOnce(spy2)
+    })
+  })
+
+  describe('disconnect', function () {
+    it('disconnects all clients', function * () {
+      const client1 = new MockClient({id: 'http://ledger1.mock'})
+      const client2 = new MockClient({id: 'http://ledger2.mock'})
+      this.core.addClient(client1)
+      this.core.addClient(client2)
+
+      const spy1 = sinon.spy(client1, 'disconnect')
+      const spy2 = sinon.spy(client2, 'disconnect')
+      yield this.core.disconnect()
+      assert.calledOnce(spy1)
+      assert.calledOnce(spy2)
+    })
+  })
+})

--- a/test/mocks/mock-client.js
+++ b/test/mocks/mock-client.js
@@ -1,0 +1,17 @@
+'use strict'
+
+const EventEmitter = require('eventemitter2')
+
+class MockClient extends EventEmitter {
+  constructor (opts) {
+    super()
+    this.plugin = opts
+  }
+
+  getPlugin () { return this.plugin }
+
+  connect () { return Promise.resolve(null) }
+  disconnect () { return Promise.resolve(null) }
+}
+
+module.exports = MockClient


### PR DESCRIPTION
Set up `Core` to replace five-bells-connector's `Multiledger` class. Right now `address` is still a ledger URI, but eventually it can be more like https://github.com/interledger/rfcs/issues/31.

This class will be used to fix https://github.com/interledger/five-bells-connector/issues/187

cc: @justmoon 