### PR TITLE
refactor: pass in plugin constructor instead of string type

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ npm install --save ilp-core ilp-plugin-bells
 import { Client } from 'ilp-core'
 
 const client = new Client({
-  type: 'bells',
+  plugin: require('ilp-plugin-bells'),
   auth: {
     account: 'https://red.ilpdemo.org/ledger/accounts/alice',
     password: 'alice'
@@ -67,7 +67,7 @@ client.on('fulfill_execution_condition', (transfer, fulfillment) => {
 import { Client } from 'ilp-core'
 
 const client = new Client({
-  type: 'bells',
+  plugin: require('ilp-plugin-bells'),
   auth: {
     account: 'https://blue.ilpdemo.org/ledger/accounts/bob',
     password: 'bobbob'
@@ -109,7 +109,7 @@ class MyExtension {
 }
 
 const client = new Client({
-  type: 'bells',
+  plugin: require('ilp-plugin-bells'),
   auth: {
     account: 'https://blue.ilpdemo.org/ledger/accounts/bob',
     password: 'bobbob'

--- a/src/lib/client.js
+++ b/src/lib/client.js
@@ -17,11 +17,11 @@ class Client extends EventEmitter {
       throw new TypeError('Client options must be an object')
     }
 
-    if (typeof opts.type !== 'string' || !opts.type.length) {
-      throw new TypeError('Plugin type must be a non-empty string')
+    if (typeof opts.plugin !== 'function') {
+      throw new TypeError('"plugin" must be a function')
     }
 
-    const Plugin = require('ilp-plugin-' + opts.type)
+    const Plugin = opts.plugin
 
     this.plugin = new Plugin(opts)
     this.connecting = false

--- a/test/clientSpec.js
+++ b/test/clientSpec.js
@@ -8,25 +8,15 @@ chai.use(chaiAsPromised)
 const assert = chai.assert
 const nock = require('nock')
 
-const mockRequire = require('mock-require')
-
 const ilpCore = require('..')
 const Client = ilpCore.Client
 const MockPlugin = require('./mocks/mock-plugin')
 
 describe('Client', function () {
-  beforeEach(function () {
-    mockRequire('ilp-plugin-mock', MockPlugin)
-  })
-
-  afterEach(function () {
-    mockRequire.stopAll()
-  })
-
   describe('constructor', function () {
     it('should instantiate the ledger plugin', function () {
       const client = new Client({
-        type: 'mock'
+        plugin: MockPlugin
       })
 
       assert.instanceOf(client, Client)
@@ -36,19 +26,19 @@ describe('Client', function () {
     it('should fail if the ledger plugin does not exist', function () {
       assert.throws(() => {
         return new Client({
-          type: 'fake',
+          plugin: null,
           auth: {
             mock: true
           }
         })
-      }, 'Cannot find module \'ilp-plugin-fake\'')
+      }, '"plugin" must be a function')
     })
   })
 
   describe('connect', function () {
     it('should call connect on the plugin', function * () {
       const client = new Client({
-        type: 'mock'
+        plugin: MockPlugin
       })
       const stubConnect = sinon.stub(client.getPlugin(), 'connect')
 
@@ -62,7 +52,7 @@ describe('Client', function () {
   describe('disconnect', function () {
     it('should call disconnect on the plugin', function * () {
       const client = new Client({
-        type: 'mock'
+        plugin: MockPlugin
       })
       const stubDisconnect = sinon.stub(client.getPlugin(), 'disconnect')
 
@@ -76,7 +66,7 @@ describe('Client', function () {
   describe('fulfillCondition', function () {
     it('should call fulfillCondition on the plugin', function * () {
       const client = new Client({
-        type: 'mock'
+        plugin: MockPlugin
       })
       const stubDisconnect = sinon.stub(client.getPlugin(), 'fulfillCondition')
 
@@ -91,7 +81,7 @@ describe('Client', function () {
   describe('waitForConnection', function () {
     it('should return a rejected promise if not currently connecting', function * () {
       const client = new Client({
-        type: 'mock'
+        plugin: MockPlugin
       })
 
       client.disconnect()
@@ -104,7 +94,7 @@ describe('Client', function () {
   describe('quote', function () {
     beforeEach(function () {
       this.client = new Client({
-        type: 'mock'
+        plugin: MockPlugin
       })
     })
 
@@ -262,7 +252,7 @@ describe('Client', function () {
   describe('sendQuotedPayment', function () {
     beforeEach(function () {
       this.client = new Client({
-        type: 'mock'
+        plugin: MockPlugin
       })
     })
 
@@ -383,7 +373,7 @@ describe('Client', function () {
   describe('use', function () {
     beforeEach(function () {
       this.client = new Client({
-        type: 'mock'
+        plugin: MockPlugin
       })
     })
 


### PR DESCRIPTION
When using `require('ilp-plugin-' + opts.type)`, ilp-core is incompatible with webpack. Additionally, it is simpler to pass in a `require`d module instead of a `type` string. The field is called `"constructor"` right now, because it's the constructor of a LedgerPlugin.