### PR TITLE
feat: [BREAKING] update plugin options

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,10 @@ const Core = require('ilp-core').Core
 const core = new Core()
 core.addClient('ilpdemo.red',
   new Client({
-    plugin: require('ilp-plugin-bells'),
-    auth: {
-      prefix: 'ilpdemo.red',
-      account: 'https://red.ilpdemo.org/ledger/accounts/alice',
-      password: 'alice'
-    }
+    _plugin: require('ilp-plugin-bells'),
+    prefix: 'ilpdemo.red',
+    account: 'https://red.ilpdemo.org/ledger/accounts/alice',
+    password: 'alice'
   }))
 
 core.connect()
@@ -107,12 +105,10 @@ class MyExtension {
 }
 
 const client = new Client({
-  plugin: require('ilp-plugin-bells'),
-  auth: {
-    prefix: 'ilpdemo.red',
-    account: 'https://blue.ilpdemo.org/ledger/accounts/bob',
-    password: 'bobbob'
-  }
+  _plugin: require('ilp-plugin-bells'),
+  prefix: 'ilpdemo.red',
+  account: 'https://blue.ilpdemo.org/ledger/accounts/bob',
+  password: 'bobbob'
 })
 
 client.use(MyExtension)

--- a/src/lib/client.js
+++ b/src/lib/client.js
@@ -17,11 +17,11 @@ class Client extends EventEmitter {
       throw new TypeError('Client options must be an object')
     }
 
-    if (typeof opts.plugin !== 'function') {
+    if (typeof opts._plugin !== 'function') {
       throw new TypeError('"plugin" must be a function')
     }
 
-    const Plugin = opts.plugin
+    const Plugin = opts._plugin
 
     this.plugin = new Plugin(opts)
     this.connecting = false

--- a/test/clientSpec.js
+++ b/test/clientSpec.js
@@ -16,7 +16,7 @@ describe('Client', function () {
   describe('constructor', function () {
     it('should instantiate the ledger plugin', function () {
       const client = new Client({
-        plugin: MockPlugin
+        _plugin: MockPlugin
       })
 
       assert.instanceOf(client, Client)
@@ -26,10 +26,8 @@ describe('Client', function () {
     it('should fail if the ledger plugin does not exist', function () {
       assert.throws(() => {
         return new Client({
-          plugin: null,
-          auth: {
-            mock: true
-          }
+          _plugin: null,
+          mock: true
         })
       }, '"plugin" must be a function')
     })
@@ -38,7 +36,7 @@ describe('Client', function () {
   describe('connect', function () {
     it('should call connect on the plugin', function * () {
       const client = new Client({
-        plugin: MockPlugin
+        _plugin: MockPlugin
       })
       const stubConnect = sinon.stub(client.getPlugin(), 'connect')
 
@@ -52,7 +50,7 @@ describe('Client', function () {
   describe('disconnect', function () {
     it('should call disconnect on the plugin', function * () {
       const client = new Client({
-        plugin: MockPlugin
+        _plugin: MockPlugin
       })
       const stubDisconnect = sinon.stub(client.getPlugin(), 'disconnect')
 
@@ -66,7 +64,7 @@ describe('Client', function () {
   describe('fulfillCondition', function () {
     it('should call fulfillCondition on the plugin', function * () {
       const client = new Client({
-        plugin: MockPlugin
+        _plugin: MockPlugin
       })
       const stubDisconnect = sinon.stub(client.getPlugin(), 'fulfillCondition')
 
@@ -81,7 +79,7 @@ describe('Client', function () {
   describe('waitForConnection', function () {
     it('should return a rejected promise if not currently connecting', function * () {
       const client = new Client({
-        plugin: MockPlugin
+        _plugin: MockPlugin
       })
 
       client.disconnect()
@@ -94,7 +92,7 @@ describe('Client', function () {
   describe('quote', function () {
     beforeEach(function () {
       this.client = new Client({
-        plugin: MockPlugin
+        _plugin: MockPlugin
       })
     })
 
@@ -283,7 +281,7 @@ describe('Client', function () {
   describe('sendQuotedPayment', function () {
     beforeEach(function () {
       this.client = new Client({
-        plugin: MockPlugin
+        _plugin: MockPlugin
       })
     })
 
@@ -394,7 +392,7 @@ describe('Client', function () {
   describe('use', function () {
     beforeEach(function () {
       this.client = new Client({
-        plugin: MockPlugin
+        _plugin: MockPlugin
       })
     })
 


### PR DESCRIPTION
Addresses issue interledger/rfcs#55 . Instead of separating pluginOptions into auth and other options, the structure is flattened and special fields (such as store) are prefixed with an underscore. To work with `ilp-plugin-bells` and `ilp-plugin-virtual` it requires https://github.com/interledger/js-ilp-plugin-bells/pull/22 and https://github.com/interledger/js-ilp-plugin-virtual/pull/5, respectively.