### PR TITLE
fix: [BREAKING] use new plugin events

### DIFF
--- a/src/lib/client.js
+++ b/src/lib/client.js
@@ -26,12 +26,20 @@ class Client extends EventEmitter {
     this.plugin = new Plugin(opts)
     this.connecting = false
 
-    this.plugin
-      .on('receive', (transfer) => this.emitAsync('receive', transfer))
-      .on('fulfill_execution_condition', (transfer, fulfillment) =>
-        this.emitAsync('fulfill_execution_condition', transfer, fulfillment))
-      .on('fulfill_cancellation_condition', (transfer, fulfillment) =>
-        this.emitAsync('fulfill_cancellation_condition', transfer, fulfillment))
+    // listen for all events in both the incoming and outgoing directions
+    for (let direction of ['incoming', 'outgoing']) {
+      this.plugin
+        .on(direction + '_transfer', (transfer) =>
+          this.emitAsync(direction + '_transfer', transfer))
+        .on(direction + '_prepare', (transfer) =>
+          this.emitAsync(direction + '_prepare', transfer))
+        .on(direction + '_fulfill', (transfer, fulfillment) =>
+          this.emitAsync(direction + '_fulfill', transfer, fulfillment))
+        .on(direction + '_cancel', (transfer, reason) =>
+          this.emitAsync(direction + '_cancel', transfer, reason))
+        .on(direction + '_reject', (transfer, reason) =>
+          this.emitAsync(direction + '_reject', transfer, reason))
+    }
 
     this._extensions = {}
   }

--- a/test/clientSpec.js
+++ b/test/clientSpec.js
@@ -435,4 +435,61 @@ describe('Client', function () {
       assert.isTrue(this.client.test.method())
     })
   })
+
+  describe('events', function () {
+    beforeEach(function () {
+      this.client = new Client({
+        _plugin: MockPlugin
+      })
+    })
+
+    const testEvent = (client, name) => {
+      const incoming = new Promise(resolve =>
+        client.on('incoming_' + name, resolve))
+      const outgoing = new Promise(resolve =>
+        client.on('outgoing_' + name, resolve))
+
+      client.plugin.emit('incoming_' + name)
+      client.plugin.emit('outgoing_' + name)
+
+      return Promise.all([incoming, outgoing])
+        // make sure the tests don't pass if the error is logged
+        .catch((e) => { console.error; throw e })
+    }
+
+    it('should emit `*_transfer` from plugin', function (done) {
+      testEvent(this.client, 'transfer')
+        .then(() => {
+          done()
+        })
+    })
+
+    it('should emit `*_prepare` from plugin', function (done) {
+      testEvent(this.client, 'prepare')
+        .then(() => {
+          done()
+        })
+    })
+
+    it('should emit `*_fulfill` from plugin', function (done) {
+      testEvent(this.client, 'fulfill')
+        .then(() => {
+          done()
+        })
+    })
+
+    it('should emit `*_cancel` from plugin', function (done) {
+      testEvent(this.client, 'cancel')
+        .then(() => {
+          done()
+        })
+    })
+
+    it('should emit `*_reject` from plugin', function (done) {
+      testEvent(this.client, 'reject')
+        .then(() => {
+          done()
+        })
+    })
+  })
 })


### PR DESCRIPTION
Addresses https://github.com/interledger/js-ilp-core/issues/37. Emits the new ledger plugin events from the plugin, instead of the outdated `fulfill_execution_condition`, `receive`, etc. 